### PR TITLE
fix initial form load with checkbox

### DIFF
--- a/src/lib/components/FormFlow/index.svelte
+++ b/src/lib/components/FormFlow/index.svelte
@@ -48,8 +48,6 @@
         }
     }
 
-    $: formType = $activeResponses[Number($response)].type.type
-
     $: setContext("id", $response)
 </script>
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store";
+import { derived, get, writable } from "svelte/store";
 import type { Form, Response, Team, Match } from "$lib/types";
 import { persisted } from "../../node_modules/svelte-persisted-store/dist/index";
 
@@ -39,3 +39,5 @@ export const theme = persisted("theme", "arctos");
 
 //A list of IDs and boolean values for whether or not those forms have errors?
 export const errors = persisted<Record<number, boolean>>("errors", {});
+
+export const formType = derived(response, ($response) => $response ? (get(activeResponses)[$response].type.type) : undefined)

--- a/src/routes/form/+page.svelte
+++ b/src/routes/form/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-    import { response, activeResponses } from "$lib/store";
+    import { response, activeResponses, formType } from "$lib/store";
     import FormFlow from "$lib/components/FormFlow/index.svelte";
     import FormsList from "$lib/components/FormsList.svelte";
   </script>
   
   {#if $response}
-    <FormFlow formType={$activeResponses[$response].type.type} />
+    <FormFlow formType={$formType} />
   {:else}
     <FormsList />
   {/if}


### PR DESCRIPTION
as long as we the form schema never changes during runtime this will work, this fixes the problem as now we only depend on the response for the formType meaning we won't rerender when the checkboxes change the form data on there initial load